### PR TITLE
Bootstrap schema loader and fixture runner

### DIFF
--- a/QA.md
+++ b/QA.md
@@ -1,0 +1,23 @@
+# Acceptance and Verification Plan
+
+## A. Count Consistency
+- **Input**: `deck_drain_sequence.json`
+- **Check**: Running and true counts match `expectedSnapshots` (respecting rounding rules).
+
+## B. Strategy Flip Determinism
+- **Input**: `strategy_flip_cases.json`
+- **Check**: For each case, `advise()` returns `below` when TC < threshold and `atOrAbove` when TC ≥ threshold, including the `deviationTag`.
+
+## C. Fixture Playback Integrity
+- **Input**: `stream_simple_round.json`
+- **Check**: Events flow through adapters and `finalizeRound` produces export values within tolerance of `export_expected_summary.json`.
+
+## D. Splits and Doubles State Machine
+- **Input**: `stream_split_double_round.json`
+- **Check**: Multiple hands are tracked, doubles adjust bet accounting, and the round closes with separate outcomes.
+
+## E. Performance Budget
+- **Check**: Observation to updated advice occurs within 500 ms (95th percentile measured via timestamps in logs).
+
+## F. Operator Overrides
+- **Check**: Inject three incorrect observations; user overrides within 5 seconds total; no corrupted state; audit log shows both original and corrected entries.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# Blackjack Card-Counting Assistant
+
+## Project Purpose
+A desktop app that watches a blackjack table on screen, understands the dealt cards and hand states in real time, keeps an accurate running and true count, and provides bet and play advice with logs and exports.
+
+## High-Level Modules
+- **Capture Layer**: handles screen or window frame capture.
+- **Vision Adapter**: converts captured frames into `CardObservations[]`.
+- **Table Mapper**: translates calibrated seat and dealer zones.
+- **Game State Tracker**: maintains round, hand, and deck state.
+- **Counting Engine**: computes running and true counts using a profile.
+- **Strategy Advisor**: surfaces basic strategy actions plus true-count deviations.
+- **Bet Sizing Engine**: suggests hand count and unit size based on true count and bankroll.
+- **UI Layer**: provides visualization, controls, and tooltips.
+- **Persistence & Export**: produces CSV/JSON session logs.
+
+## Repository Layout
+```
+/requirements.md
+/contracts/
+  card_observation.schema.json
+  zones_config.schema.json
+  count_profile.schema.json
+  rules_config.schema.json
+  risk_model.schema.json
+  advice.schema.json
+  capture_api.schema.json
+  vision_api.schema.json
+  game_state_api.schema.json
+  strategy_api.schema.json
+  bet_api.schema.json
+  persistence_api.schema.json
+/fixtures/
+  stream_simple_round.json
+  stream_split_double_round.json
+  deck_drain_sequence.json
+  strategy_flip_cases.json
+  export_expected_summary.json
+/QA.md
+/ROADMAP.md
+```
+
+## Zero-Assumption Starter Tasks
+1. **Contracts First**: load schemas from `/contracts`, generate typed stubs in the chosen language, and wire no-op adapters that echo fixtures end to end.
+2. **Fixture Playback**: build a runner that feeds `/fixtures/stream_*.json` into the pipeline and produces `/tmp/advice.log` and `/tmp/export.json`.
+3. **Acceptance Harness**: implement the checks described in `QA.md` against the runner output.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,31 @@
+# Implementation Roadmap
+
+## M1 — Contracts & Skeleton (Day 1–2)
+- Load schemas.
+- Generate typed interfaces.
+- Create no-op adapters that pass fixtures through.
+- Build a CLI runner that replays `/fixtures/*` to the console.
+
+## M2 — Zones & Calibration (Day 2–3)
+- Implement region selection persistence.
+- Load and save `zones_config`.
+- Render seat and dealer boxes in a placeholder UI.
+
+## M3 — Round Engine (Day 3–4)
+- Implement `beginRound`, `commitObservation`, and `finalizeRound` with multi-hand support for splits and doubles.
+- Add a counting engine with profile loading and manual decks-remaining control.
+
+## M4 — Advice Engines (Day 4–5)
+- Strategy advisor: basic table plus deviation thresholds driven by data.
+- Bet sizing: load risk model; enforce table limits and bankroll.
+
+## M5 — Fixture Green (Day 5–6)
+- Ensure all QA cases pass on fixture playback.
+
+## M6 — Capture & Vision Adapters (Day 6–8)
+- Wire real capture sources.
+- Plug a provisional vision adapter that returns `CardObservations[]`.
+- Add override UI and hotkeys.
+
+## M7 — Export & Polish (Day 8–9)
+- CSV and JSON export, session summaries, penetration warnings, tooltips, and status bar improvements.

--- a/contracts/advice.schema.json
+++ b/contracts/advice.schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "advice.schema.json",
+  "type": "object",
+  "properties": {
+    "bet": {
+      "type": "object",
+      "required": ["handCount", "unitSize", "rationale"],
+      "properties": {
+        "handCount": { "type": "integer", "enum": [1, 2] },
+        "unitSize": { "type": "number" },
+        "rationale": { "type": "string" }
+      }
+    },
+    "play": {
+      "type": "object",
+      "required": ["action"],
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": ["Hit", "Stand", "Double", "Split", "Surrender", "Insurance"]
+        },
+        "deviationTag": { "type": ["string", "null"] },
+        "tooltip": { "type": ["string", "null"] }
+      }
+    }
+  }
+}

--- a/contracts/bet_api.schema.json
+++ b/contracts/bet_api.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "bet_api.schema.json",
+  "type": "object",
+  "properties": {
+    "methods": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["suggest", "loadRiskModel"]
+      }
+    },
+    "suggest_return": {
+      "type": "object",
+      "properties": {
+        "bet": { "$ref": "advice.schema.json#/properties/bet" }
+      }
+    }
+  }
+}

--- a/contracts/capture_api.schema.json
+++ b/contracts/capture_api.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "capture_api.schema.json",
+  "type": "object",
+  "properties": {
+    "methods": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["start", "stop", "onFrame", "setRegion", "listSources"]
+      }
+    }
+  },
+  "description": "Capture adapter must expose start(sourceId, region), stop(), onFrame(cb(bitmap,timestamp)), setRegion(region), listSources()"
+}

--- a/contracts/card_observation.schema.json
+++ b/contracts/card_observation.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "card_observation.schema.json",
+  "type": "object",
+  "required": ["timestamp", "zoneId", "rank", "confidence"],
+  "properties": {
+    "timestamp": { "type": "number", "description": "Unix seconds with fraction" },
+    "zoneId": { "type": "string", "description": "seat_1..seat_7 or dealer" },
+    "rank": {
+      "type": "string",
+      "enum": ["A", "2", "3", "4", "5", "6", "7", "8", "9", "10", "J", "Q", "K"]
+    },
+    "suit": {
+      "type": ["string", "null"],
+      "enum": ["S", "H", "D", "C", null]
+    },
+    "confidence": { "type": "number", "minimum": 0, "maximum": 1 },
+    "bbox": {
+      "type": "array",
+      "items": { "type": "number" },
+      "minItems": 4,
+      "maxItems": 4
+    }
+  }
+}

--- a/contracts/count_profile.schema.json
+++ b/contracts/count_profile.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "count_profile.schema.json",
+  "type": "object",
+  "required": ["name", "tags"],
+  "properties": {
+    "name": { "type": "string" },
+    "tags": {
+      "type": "object",
+      "additionalProperties": { "type": "number" }
+    },
+    "roundDownTrueCount": { "type": "boolean", "default": true }
+  }
+}

--- a/contracts/game_state_api.schema.json
+++ b/contracts/game_state_api.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "game_state_api.schema.json",
+  "type": "object",
+  "properties": {
+    "methods": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "beginRound",
+          "commitObservation",
+          "overrideCard",
+          "finalizeRound",
+          "resetShoe",
+          "onEvent"
+        ]
+      }
+    }
+  }
+}

--- a/contracts/persistence_api.schema.json
+++ b/contracts/persistence_api.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "persistence_api.schema.json",
+  "type": "object",
+  "properties": {
+    "methods": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "saveSession",
+          "loadSession",
+          "exportCSV",
+          "exportJSON",
+          "appendLog"
+        ]
+      }
+    }
+  }
+}

--- a/contracts/risk_model.schema.json
+++ b/contracts/risk_model.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "risk_model.schema.json",
+  "type": "object",
+  "required": ["name", "unitBase", "maxUnit", "kellyFraction"],
+  "properties": {
+    "name": { "type": "string" },
+    "unitBase": { "type": "number", "minimum": 0 },
+    "maxUnit": { "type": "number", "minimum": 0 },
+    "twoHandThresholdTC": { "type": "number" },
+    "kellyFraction": { "type": "number", "minimum": 0 },
+    "minEnterTC": { "type": "number", "default": 1 }
+  }
+}

--- a/contracts/rules_config.schema.json
+++ b/contracts/rules_config.schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "rules_config.schema.json",
+  "type": "object",
+  "required": ["decks", "blackjackPays", "dealerHitsSoft17"],
+  "properties": {
+    "decks": { "type": "integer", "minimum": 1 },
+    "blackjackPays": { "type": "string", "enum": ["3:2", "6:5"] },
+    "dealerHitsSoft17": { "type": "boolean" },
+    "doubleAfterSplit": { "type": "boolean", "default": true },
+    "splitAcesOnce": { "type": "boolean", "default": true },
+    "surrender": {
+      "type": "string",
+      "enum": ["none", "late", "early"],
+      "default": "none"
+    }
+  }
+}

--- a/contracts/strategy_api.schema.json
+++ b/contracts/strategy_api.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "strategy_api.schema.json",
+  "type": "object",
+  "properties": {
+    "methods": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["advise", "loadTables"]
+      }
+    },
+    "advise_return": { "$ref": "advice.schema.json" }
+  }
+}

--- a/contracts/vision_api.schema.json
+++ b/contracts/vision_api.schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "vision_api.schema.json",
+  "type": "object",
+  "properties": {
+    "methods": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["analyzeFrame", "setTableZones", "warmup", "teardown"]
+      }
+    },
+    "analyzeFrame_return": {
+      "type": "array",
+      "items": { "$ref": "card_observation.schema.json" }
+    }
+  }
+}

--- a/contracts/zones_config.schema.json
+++ b/contracts/zones_config.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "zones_config.schema.json",
+  "type": "object",
+  "required": ["region", "zones"],
+  "properties": {
+    "region": {
+      "type": "object",
+      "properties": {
+        "x": { "type": "number" },
+        "y": { "type": "number" },
+        "w": { "type": "number" },
+        "h": { "type": "number" }
+      },
+      "required": ["x", "y", "w", "h"]
+    },
+    "zones": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "polygon"],
+        "properties": {
+          "id": { "type": "string" },
+          "polygon": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": { "type": "number" },
+              "minItems": 2,
+              "maxItems": 2
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/fixtures/deck_drain_sequence.json
+++ b/fixtures/deck_drain_sequence.json
@@ -1,0 +1,28 @@
+{
+  "countProfile": {
+    "name": "TestProfile",
+    "tags": {
+      "2": 0.5,
+      "3": 1,
+      "4": 1,
+      "5": 1.5,
+      "6": 1,
+      "7": 0.5,
+      "8": 0,
+      "9": -0.5,
+      "10": -1,
+      "J": -1,
+      "Q": -1,
+      "K": -1,
+      "A": -1
+    },
+    "roundDownTrueCount": true
+  },
+  "decks": 1,
+  "cards": ["2", "3", "4", "5", "6", "7", "8", "9", "10", "J", "Q", "K", "A", "2", "2", "2", "9", "9", "9", "A", "A", "A"],
+  "expectedSnapshots": [
+    { "index": 4, "running": 5.0, "true": 5.0 },
+    { "index": 12, "running": 1.0, "true": 1.0 },
+    { "index": 20, "running": 2.5, "true": 3.0 }
+  ]
+}

--- a/fixtures/export_expected_summary.json
+++ b/fixtures/export_expected_summary.json
@@ -1,0 +1,11 @@
+{
+  "hands": 3,
+  "wins": 2,
+  "losses": 1,
+  "pushes": 0,
+  "blackjacks": 1,
+  "avgBet": 15,
+  "net": 17.5,
+  "stdev": 1.2,
+  "penDepth": 0.12
+}

--- a/fixtures/strategy_flip_cases.json
+++ b/fixtures/strategy_flip_cases.json
@@ -1,0 +1,26 @@
+[
+  {
+    "player": "16",
+    "dealer": "10",
+    "thresholdTC": 0,
+    "below": "Hit",
+    "atOrAbove": "Stand",
+    "tag": "16v10@TC>=0"
+  },
+  {
+    "player": "12",
+    "dealer": "3",
+    "thresholdTC": 2,
+    "below": "Hit",
+    "atOrAbove": "Stand",
+    "tag": "12v3@TC>=2"
+  },
+  {
+    "player": "9",
+    "dealer": "2",
+    "thresholdTC": 1,
+    "below": "Hit",
+    "atOrAbove": "Double",
+    "tag": "9v2@TC>=1"
+  }
+]

--- a/fixtures/stream_simple_round.json
+++ b/fixtures/stream_simple_round.json
@@ -1,0 +1,50 @@
+{
+  "zonesConfig": {
+    "region": { "x": 100, "y": 100, "w": 1280, "h": 720 },
+    "zones": [
+      { "id": "dealer", "polygon": [[0.45, 0.05], [0.55, 0.05], [0.55, 0.15], [0.45, 0.15]] },
+      { "id": "seat_1", "polygon": [[0.10, 0.60], [0.20, 0.60], [0.20, 0.85], [0.10, 0.85]] },
+      { "id": "seat_2", "polygon": [[0.30, 0.60], [0.40, 0.60], [0.40, 0.85], [0.30, 0.85]] },
+      { "id": "seat_3", "polygon": [[0.50, 0.60], [0.60, 0.60], [0.60, 0.85], [0.50, 0.85]] }
+    ]
+  },
+  "rules": {
+    "decks": 8,
+    "blackjackPays": "3:2",
+    "dealerHitsSoft17": false,
+    "doubleAfterSplit": true,
+    "splitAcesOnce": true,
+    "surrender": "none"
+  },
+  "countProfile": {
+    "name": "WongHalvesLike",
+    "tags": { "2": 0.5, "3": 1, "4": 1, "5": 1.5, "6": 1, "7": 0.5, "8": 0, "9": -0.5, "10": -1, "J": -1, "Q": -1, "K": -1, "A": -1 },
+    "roundDownTrueCount": true
+  },
+  "riskModel": {
+    "name": "ConservativeKelly",
+    "unitBase": 5,
+    "maxUnit": 150,
+    "twoHandThresholdTC": 3,
+    "kellyFraction": 0.033,
+    "minEnterTC": 1
+  },
+  "events": [
+    { "t": 0.10, "obs": { "zoneId": "seat_1", "rank": "10", "confidence": 0.97 } },
+    { "t": 0.12, "obs": { "zoneId": "seat_2", "rank": "5", "confidence": 0.96 } },
+    { "t": 0.15, "obs": { "zoneId": "seat_3", "rank": "9", "confidence": 0.95 } },
+    { "t": 0.20, "obs": { "zoneId": "dealer", "rank": "6", "confidence": 0.98 } },
+    { "t": 0.40, "obs": { "zoneId": "seat_1", "rank": "A", "confidence": 0.96 } },
+    { "t": 0.45, "obs": { "zoneId": "seat_2", "rank": "K", "confidence": 0.95 } },
+    { "t": 0.50, "obs": { "zoneId": "seat_3", "rank": "7", "confidence": 0.94 } },
+    {
+      "t": 0.80,
+      "command": "finalizeRound",
+      "outcomes": [
+        { "seatId": "seat_1", "result": "blackjack" },
+        { "seatId": "seat_2", "result": "loss" },
+        { "seatId": "seat_3", "result": "win" }
+      ]
+    }
+  ]
+}

--- a/fixtures/stream_split_double_round.json
+++ b/fixtures/stream_split_double_round.json
@@ -1,0 +1,35 @@
+{
+  "zonesConfig": {
+    "region": { "x": 0, "y": 0, "w": 1920, "h": 1080 },
+    "zones": [
+      { "id": "dealer", "polygon": [[0.46, 0.08], [0.54, 0.08], [0.54, 0.16], [0.46, 0.16]] },
+      { "id": "seat_2", "polygon": [[0.30, 0.62], [0.40, 0.62], [0.40, 0.88], [0.30, 0.88]] }
+    ]
+  },
+  "rules": {
+    "decks": 8,
+    "blackjackPays": "3:2",
+    "dealerHitsSoft17": false
+  },
+  "countProfile": {
+    "name": "AltCount",
+    "tags": { "2": 1, "3": 1, "4": 1, "5": 1, "6": 1, "7": 0, "8": 0, "9": 0, "10": -1, "J": -1, "Q": -1, "K": -1, "A": -1 }
+  },
+  "events": [
+    { "t": 0.10, "obs": { "zoneId": "seat_2", "rank": "8", "confidence": 0.97 } },
+    { "t": 0.14, "obs": { "zoneId": "seat_2", "rank": "8", "confidence": 0.95 } },
+    { "t": 0.18, "command": "split", "seatId": "seat_2" },
+    { "t": 0.20, "obs": { "zoneId": "seat_2", "rank": "3", "confidence": 0.95 } },
+    { "t": 0.23, "obs": { "zoneId": "seat_2", "rank": "2", "confidence": 0.94 } },
+    { "t": 0.30, "command": "double", "seatId": "seat_2", "handIndex": 0 },
+    { "t": 0.35, "obs": { "zoneId": "dealer", "rank": "10", "confidence": 0.98 } },
+    {
+      "t": 0.80,
+      "command": "finalizeRound",
+      "outcomes": [
+        { "seatId": "seat_2", "result": "win", "handIndex": 0 },
+        { "seatId": "seat_2", "result": "loss", "handIndex": 1 }
+      ]
+    }
+  ]
+}

--- a/requirements.md
+++ b/requirements.md
@@ -1,0 +1,31 @@
+# Product and Engineering Requirements
+
+## 1. Outcomes (Definition of Done)
+1. User selects a screen or window region to watch and the configuration persists.
+2. Cards appearing in the region are surfaced as observations with `{zoneId, rank, (optional suit), confidence}` and assigned to seats plus dealer in near real time.
+3. Running count and true count update deterministically using a selected count profile; decks remaining is adjustable and/or inferred.
+4. Strategy panel shows basic action and deviation (when true-count thresholds are met) with concise tooltip text.
+5. Bet panel recommends hand count (1 or 2) and unit size, obeying bankroll constraints and table limits via a pluggable risk model.
+6. Operator can begin rounds, mark outcomes (win/loss/push/blackjack/insurance), override a misread card, and toggle which seats are "mine" with minimal friction.
+7. Session stats (hands per hour, wagers, net, EV estimate, variance) and full logs export to CSV and JSON.
+8. Alerts surface when penetration is shallow, FPS is low, confidence is low, or a table change should be considered.
+
+## 2. Non-Functional Requirements
+- **Latency**: ≤ 500 ms from observation to updated advice.
+- **Accuracy**: 95%+ rank accuracy on clean, in-focus frames (validated via fixtures and human overrides).
+- **Resilience**: Overrides never corrupt state; every mutation is timestamped and auditable.
+- **Portability**: No hard dependency on a particular CV or GUI toolkit. Adapters must be replaceable.
+- **Privacy**: Default local processing and storage.
+
+## 3. Rules Support (Initial)
+- 8-deck shoe, Blackjack 3:2, S17 default, DAS true, surrender none (configurable via `rules_config`).
+- Two-hand player support; counting uses all observed cards.
+
+## 4. UX Essentials
+- Always visible: running count, true count, shoe depth, bet advice.
+- Quick tooltips on deviations (e.g., `16 vs 10 → Stand at TC ≥ 0; else Hit`).
+- Hotkeys for: start/next hand, mark outcomes, toggle two-hand, add/remove card, pause capture.
+
+## 5. Extensibility
+- Profiles: counting (tag weights, rounding rules), risk models (JSON driven), strategy tables (data driven).
+- Adapters: capture, vision, strategy, bets, persistence defined by minimal interfaces in `/contracts`.

--- a/src/blackjack_bot/__init__.py
+++ b/src/blackjack_bot/__init__.py
@@ -1,0 +1,33 @@
+"""Blackjack card-counting assistant skeleton package."""
+
+from .schemas import load_all_schemas, SchemaRegistry
+from .adapters import (
+    CaptureAdapter,
+    VisionAdapter,
+    GameStateTracker,
+    StrategyAdvisor,
+    BetSizingEngine,
+    PersistenceAdapter,
+    NoOpCaptureAdapter,
+    NoOpVisionAdapter,
+    NoOpGameStateTracker,
+    NoOpStrategyAdvisor,
+    NoOpBetSizingEngine,
+    InMemoryPersistenceAdapter,
+)
+__all__ = [
+    "load_all_schemas",
+    "SchemaRegistry",
+    "CaptureAdapter",
+    "VisionAdapter",
+    "GameStateTracker",
+    "StrategyAdvisor",
+    "BetSizingEngine",
+    "PersistenceAdapter",
+    "NoOpCaptureAdapter",
+    "NoOpVisionAdapter",
+    "NoOpGameStateTracker",
+    "NoOpStrategyAdvisor",
+    "NoOpBetSizingEngine",
+    "InMemoryPersistenceAdapter",
+]

--- a/src/blackjack_bot/adapters.py
+++ b/src/blackjack_bot/adapters.py
@@ -1,0 +1,127 @@
+"""Simple no-op adapter implementations used for fixture playback."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Iterator, List
+import json
+
+from .interfaces import (
+    BetAdvice,
+    BetSizingEngine,
+    CaptureAdapter,
+    CommandEvent,
+    GameStateTracker,
+    ObservationEvent,
+    PersistenceAdapter,
+    PipelineEvent,
+    StrategyAdvice,
+    StrategyAdvisor,
+    VisionAdapter,
+)
+
+
+@dataclass
+class NoOpCaptureAdapter(CaptureAdapter):
+    """Loads pre-recorded events from a fixture file."""
+
+    fixture_path: Path
+
+    def stream(self) -> Iterator[PipelineEvent]:
+        with self.fixture_path.open("r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+        for item in payload.get("events", []):
+            timestamp = float(item.get("t", 0.0))
+            if "obs" in item:
+                yield ObservationEvent(timestamp=timestamp, observation=item["obs"])
+            else:
+                command = item.get("command", "unknown")
+                payload = {
+                    key: value
+                    for key, value in item.items()
+                    if key not in {"t", "command"}
+                }
+                yield CommandEvent(timestamp=timestamp, command=command, payload=payload)
+
+
+@dataclass
+class NoOpVisionAdapter(VisionAdapter):
+    """Passes through observation events unchanged."""
+
+    def process(self, events: Iterable[PipelineEvent]) -> Iterable[PipelineEvent]:
+        return list(events)
+
+
+@dataclass
+class NoOpGameStateTracker(GameStateTracker):
+    """For now, just echoes events to downstream consumers."""
+
+    def ingest(self, events: Iterable[PipelineEvent]) -> Iterable[PipelineEvent]:
+        return list(events)
+
+
+@dataclass
+class NoOpStrategyAdvisor(StrategyAdvisor):
+    """Produces placeholder advice for every observation seat."""
+
+    default_action: str = "Stand"
+
+    def advise(self, state_events: Iterable[PipelineEvent]) -> List[StrategyAdvice]:
+        advice: List[StrategyAdvice] = []
+        for event in state_events:
+            if isinstance(event, ObservationEvent):
+                advice.append(
+                    StrategyAdvice(
+                        seatId=event.observation.get("zoneId", "seat"),
+                        handIndex=0,
+                        basicAction=self.default_action,
+                        deviationAction=None,
+                        deviationTag=None,
+                        trueCount=0.0,
+                    )
+                )
+        return advice
+
+
+@dataclass
+class NoOpBetSizingEngine(BetSizingEngine):
+    """Returns a constant bet recommendation."""
+
+    unit_size: float = 10.0
+
+    def recommend(self, state_events: Iterable[PipelineEvent]) -> List[BetAdvice]:
+        bets: List[BetAdvice] = []
+        seen_seats = set()
+        for event in state_events:
+            if isinstance(event, ObservationEvent):
+                seat = event.observation.get("zoneId", "seat")
+                if seat not in seen_seats and seat.startswith("seat"):
+                    seen_seats.add(seat)
+                    bets.append(
+                        BetAdvice(
+                            seatId=seat,
+                            hands=1,
+                            unitSize=self.unit_size,
+                            totalWager=self.unit_size,
+                        )
+                    )
+        return bets
+
+
+@dataclass
+class InMemoryPersistenceAdapter(PersistenceAdapter):
+    """Collects events into a simple export dictionary."""
+
+    def save_round(
+        self,
+        events: Iterable[PipelineEvent],
+        advice: List[StrategyAdvice],
+        bets: List[BetAdvice],
+    ) -> dict:
+        event_count = sum(1 for _ in events)
+        return {
+            "events": event_count,
+            "adviceCount": len(advice),
+            "betCount": len(bets),
+        }
+

--- a/src/blackjack_bot/interfaces.py
+++ b/src/blackjack_bot/interfaces.py
@@ -1,0 +1,107 @@
+"""Typed protocol definitions for the starter blackjack pipeline."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Literal, Optional, Protocol, Sequence, TypedDict
+
+
+class CardObservation(TypedDict, total=False):
+    timestamp: float
+    zoneId: str
+    rank: Literal["A", "2", "3", "4", "5", "6", "7", "8", "9", "10", "J", "Q", "K"]
+    suit: Optional[Literal["S", "H", "D", "C"]]
+    confidence: float
+    bbox: Sequence[float]
+
+
+class CountSnapshot(TypedDict):
+    running: float
+    true: float
+    decksRemaining: float
+
+
+class StrategyAdvice(TypedDict, total=False):
+    seatId: str
+    handIndex: int
+    basicAction: str
+    deviationAction: Optional[str]
+    deviationTag: Optional[str]
+    trueCount: float
+
+
+class BetAdvice(TypedDict):
+    seatId: str
+    hands: int
+    unitSize: float
+    totalWager: float
+
+
+class RoundExport(TypedDict, total=False):
+    hands: int
+    wins: int
+    losses: int
+    pushes: int
+    blackjacks: int
+    avgBet: float
+    net: float
+    stdev: float
+    penDepth: float
+
+
+@dataclass
+class ObservationEvent:
+    timestamp: float
+    observation: CardObservation
+
+
+@dataclass
+class CommandEvent:
+    timestamp: float
+    command: str
+    payload: dict
+
+
+PipelineEvent = ObservationEvent | CommandEvent
+
+
+class CaptureAdapter(Protocol):
+    """Produces raw frames or fixture events."""
+
+    def stream(self) -> Iterable[PipelineEvent]:  # pragma: no cover - protocol
+        ...
+
+
+class VisionAdapter(Protocol):
+    """Transforms capture output into card observations."""
+
+    def process(self, events: Iterable[PipelineEvent]) -> Iterable[PipelineEvent]:  # pragma: no cover
+        ...
+
+
+class GameStateTracker(Protocol):
+    """Maintains round state based on observations."""
+
+    def ingest(self, events: Iterable[PipelineEvent]) -> Iterable[PipelineEvent]:  # pragma: no cover
+        ...
+
+
+class StrategyAdvisor(Protocol):
+    """Calculates play advice for each seat/hand."""
+
+    def advise(self, state_events: Iterable[PipelineEvent]) -> List[StrategyAdvice]:  # pragma: no cover
+        ...
+
+
+class BetSizingEngine(Protocol):
+    """Derives bet recommendations from true count and bankroll."""
+
+    def recommend(self, state_events: Iterable[PipelineEvent]) -> List[BetAdvice]:  # pragma: no cover
+        ...
+
+
+class PersistenceAdapter(Protocol):
+    """Persists key events and exports session summaries."""
+
+    def save_round(self, events: Iterable[PipelineEvent], advice: List[StrategyAdvice], bets: List[BetAdvice]) -> RoundExport:  # pragma: no cover
+        ...
+

--- a/src/blackjack_bot/runner.py
+++ b/src/blackjack_bot/runner.py
@@ -1,0 +1,84 @@
+"""CLI runner that replays fixture streams through the no-op pipeline."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import List
+
+from .adapters import (
+    InMemoryPersistenceAdapter,
+    NoOpBetSizingEngine,
+    NoOpCaptureAdapter,
+    NoOpGameStateTracker,
+    NoOpStrategyAdvisor,
+    NoOpVisionAdapter,
+)
+from .schemas import load_all_schemas
+
+
+class Pipeline:
+    """Lightweight container composing the starter adapters."""
+
+    def __init__(self, fixture_path: Path) -> None:
+        self.fixture_path = fixture_path
+        self.capture = NoOpCaptureAdapter(fixture_path)
+        self.vision = NoOpVisionAdapter()
+        self.state_tracker = NoOpGameStateTracker()
+        self.strategy = NoOpStrategyAdvisor()
+        self.bets = NoOpBetSizingEngine()
+        self.persistence = InMemoryPersistenceAdapter()
+
+    def run(self) -> dict:
+        events = list(self.capture.stream())
+        vision_events = list(self.vision.process(events))
+        state_events = list(self.state_tracker.ingest(vision_events))
+        strategy_advice = self.strategy.advise(state_events)
+        bet_advice = self.bets.recommend(state_events)
+        export = self.persistence.save_round(state_events, strategy_advice, bet_advice)
+        return {
+            "fixture": self.fixture_path.name,
+            "events": [event.__dict__ for event in events],
+            "advice": strategy_advice,
+            "bets": bet_advice,
+            "export": export,
+        }
+
+
+def build_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "fixture",
+        help="Path to a fixture JSON file from the fixtures directory.",
+    )
+    parser.add_argument(
+        "--contracts",
+        type=Path,
+        default=None,
+        help="Optional path to the contracts directory for validation purposes.",
+    )
+    return parser
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = build_argument_parser()
+    args = parser.parse_args(argv)
+
+    fixture_path = Path(args.fixture).expanduser().resolve()
+    if not fixture_path.exists():
+        raise SystemExit(f"Fixture '{fixture_path}' does not exist.")
+
+    registry = load_all_schemas(args.contracts)
+    print(f"Loaded {len(list(registry.items()))} JSON schemas from {registry.root}.")
+
+    pipeline = Pipeline(fixture_path)
+    output = pipeline.run()
+    print(f"Replay complete for fixture: {output['fixture']}")
+    print(f"Observed {len(output['events'])} events → {len(output['advice'])} advice entries, {len(output['bets'])} bet entries.")
+    print("Export summary:")
+    for key, value in output["export"].items():
+        print(f"  {key}: {value}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/blackjack_bot/schemas.py
+++ b/src/blackjack_bot/schemas.py
@@ -1,0 +1,50 @@
+"""Utilities for loading JSON schema contracts."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable
+import json
+
+
+@dataclass
+class SchemaRegistry:
+    """Holds loaded JSON schemas keyed by filename."""
+
+    root: Path
+    schemas: Dict[str, dict]
+
+    def get(self, name: str) -> dict:
+        """Return a schema by file stem or filename."""
+        key = name
+        if not key.endswith(".json"):
+            key = f"{key}.json"
+        schema = self.schemas.get(key)
+        if schema is None:
+            raise KeyError(f"Schema '{name}' not found. Available: {sorted(self.schemas)}")
+        return schema
+
+    def items(self) -> Iterable[tuple[str, dict]]:
+        return self.schemas.items()
+
+
+def load_all_schemas(contracts_dir: Path | None = None) -> SchemaRegistry:
+    """Load every JSON schema from the contracts directory."""
+    if contracts_dir is None:
+        module_path = Path(__file__).resolve()
+        search_roots = [
+            module_path.parents[1] / "contracts",
+            module_path.parents[2] / "contracts",
+            Path.cwd() / "contracts",
+        ]
+        for candidate in search_roots:
+            if candidate.exists():
+                contracts_dir = candidate
+                break
+        else:
+            raise FileNotFoundError("Could not locate contracts directory.")
+    schemas: Dict[str, dict] = {}
+    for path in sorted(contracts_dir.glob("*.json")):
+        with path.open("r", encoding="utf-8") as handle:
+            schemas[path.name] = json.load(handle)
+    return SchemaRegistry(root=contracts_dir, schemas=schemas)


### PR DESCRIPTION
## Summary
- add a schema registry utility to load JSON contracts and expose typed interfaces
- provide no-op adapter implementations to pass fixture events end-to-end
- create a CLI runner that replays fixture streams through the starter pipeline

## Testing
- PYTHONPATH=src python -m blackjack_bot.runner fixtures/stream_simple_round.json

------
https://chatgpt.com/codex/tasks/task_e_68ddc6bda54c832d950161e2061244f4